### PR TITLE
New Main Menu and Combat Updates

### DIFF
--- a/Scenes/main_menu.tscn
+++ b/Scenes/main_menu.tscn
@@ -1,0 +1,62 @@
+[gd_scene load_steps=2 format=3 uid="uid://cihywklhjbwqs"]
+
+[ext_resource type="Script" path="res://Scripts/Main_Menu.gd" id="1_wcbli"]
+
+[node name="MainMenu" type="Node2D"]
+script = ExtResource("1_wcbli")
+
+[node name="Menu_UI" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 0
+offset_top = -1.0
+offset_right = 1161.0
+offset_bottom = 650.0
+
+[node name="Title" type="RichTextLabel" parent="Menu_UI"]
+layout_mode = 0
+offset_left = 396.0
+offset_top = 7.0
+offset_right = 872.0
+offset_bottom = 231.0
+theme_override_font_sizes/normal_font_size = 40
+text = "Redneck Redemption
+Battle for The Minifigure"
+
+[node name="Play_Button" type="Button" parent="Menu_UI"]
+layout_mode = 0
+offset_left = 120.0
+offset_top = 228.0
+offset_right = 387.0
+offset_bottom = 325.0
+theme_override_font_sizes/font_size = 40
+text = "Play"
+
+[node name="Combat_Button" type="Button" parent="Menu_UI"]
+offset_left = 744.0
+offset_top = 229.0
+offset_right = 1011.0
+offset_bottom = 326.0
+theme_override_font_sizes/font_size = 40
+text = "Combat"
+
+[node name="Settings_Button" type="Button" parent="Menu_UI"]
+offset_left = 120.0
+offset_top = 456.0
+offset_right = 387.0
+offset_bottom = 553.0
+theme_override_font_sizes/font_size = 40
+text = "Settings
+"
+
+[node name="Exit_Button" type="Button" parent="Menu_UI"]
+offset_left = 744.0
+offset_top = 458.0
+offset_right = 1011.0
+offset_bottom = 555.0
+theme_override_font_sizes/font_size = 40
+text = "Exit
+"
+
+[connection signal="pressed" from="Menu_UI/Play_Button" to="." method="_on_play_button_pressed"]
+[connection signal="pressed" from="Menu_UI/Combat_Button" to="." method="_on_combat_button_pressed"]
+[connection signal="pressed" from="Menu_UI/Exit_Button" to="." method="_on_exit_button_pressed"]

--- a/Scripts/Main_Menu.gd
+++ b/Scripts/Main_Menu.gd
@@ -1,0 +1,23 @@
+extends Node
+
+# Menu Buttons for Access
+@onready var play_button = $Menu_UI/Play_Button
+@onready var combat_button = $Menu_UI/Combat_Button
+@onready var settings_button = $Menu_UI/Settings_Button
+@onready var exit_button = $Menu_UI/Exit_Button
+
+
+func _on_play_button_pressed():
+	# Open player.tscn
+	get_tree().change_scene_to_file("res://Scenes/player.tscn")
+	
+
+func _on_combat_button_pressed():
+	# Open combat.tscn
+	get_tree().change_scene_to_file("res://Scenes/combat.tscn")
+	
+
+
+func _on_exit_button_pressed():
+	# Exit and close game
+	get_tree().quit()

--- a/Scripts/Player.gd
+++ b/Scripts/Player.gd
@@ -49,3 +49,9 @@ func player_animation(dir_x, dir_y):
 		animated_sprite_2d.play("Idle")
 	else:
 		animated_sprite_2d.play("Running")
+		
+# Easy Debug Escape
+func _input(ev):
+	if Input.is_key_pressed(KEY_ESCAPE):
+		get_tree().quit()
+

--- a/Scripts/Player_States.gd
+++ b/Scripts/Player_States.gd
@@ -1,7 +1,14 @@
 extends Node
 
+# Player Stats
 var max_hp = 25
 var hp = max_hp: set = set_hp
+
+var _attack = 4
+var _defence = 1
+
+var _exp = 0
+var _max_exp = 10
 
 var max_ap = 10
 var ap = max_ap: set = set_ap
@@ -17,3 +24,21 @@ func set_hp(value):
 func set_ap(value):
 	ap = min(value, max_ap)
 	emit_signal("ap_changed", ap)
+	
+func get_attack():
+	# Get The Player Attack
+	return _attack
+
+func set_attack(value):
+	# Set the Value of Player Attack to New Number
+	_attack = value
+		
+func get_defence():
+	# Get the Player Defence
+	return _defence
+
+func set_defence(value):
+	# Set the Value of Player Defence to New Number
+	_defence = value	
+	
+

--- a/Scripts/combat.gd
+++ b/Scripts/combat.gd
@@ -3,15 +3,21 @@ extends Node
 @onready var enemy = $Enemy
 @onready var attack_button = $UI/GridContainer/Attack_Button
 @onready var player_animations = $Player/Player_Animations
+@onready var player_states = $Player_States
 
 func _on_attack_button_pressed():
 	if enemy != null:
 		player_animations.play("Punch")
 		await (player_animations.animation_finished)
-		enemy.hp -= 4
+		enemy.hp -= player_states.get_attack()
 		player_animations.play("Idle")
 
 
 func _on_test_enemy_died():
 	attack_button.hide()
 	enemy = null
+
+# Easy Debug Exit
+func _input(ev):
+	if Input.is_key_pressed(KEY_ESCAPE):
+		get_tree().quit()

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="CMPT-230 Team #1"
-run/main_scene="res://Scenes/game.tscn"
+run/main_scene="res://Scenes/main_menu.tscn"
 config/features=PackedStringArray("4.2", "Forward Plus")
 config/icon="res://Assets/icon.svg"
 


### PR DESCRIPTION
What's New?
- Added a Main Menu Screen, which contains 4 Buttons: - Play: Takes you to the main overworld player scene - Combat: Takes you to the combat scene - Options: Which does not do anything at the moment - Quit: Which exits and closes the game

- In the Player.tscn and Combat.tscn, the ESC key has been mapped to close the game immediately, allowing for easier switching between coding and testing

- The Combat has been adjusted in terms of dealing damage and Player stats: - Player_States.gd now contains an _attack and _defence stats which all contain a get and set function. When damage is being dealt to the enemy, these functions will be called. - Stats for EXP and Max EXP have been added as well, but no functions and uses have been implemented for those